### PR TITLE
Add layout-independent Unicode typing mode for RDP

### DIFF
--- a/Native.cs
+++ b/Native.cs
@@ -84,6 +84,9 @@ namespace ClickPaste
         public const byte VK_LSHIFT = 0xA0;
         public const byte VK_LCONTROL = 0xA2;
         public const byte VK_RMENU = 0xA5;
+        public const byte VK_BACK = 0x08;
+        public const byte VK_TAB = 0x09;
+        public const byte VK_RETURN = 0x0D;
         public const byte VK_NUMPAD0 = 0x60;
         public const byte VK_NUMPAD1 = 0x61;
         public const byte VK_NUMPAD2 = 0x62;
@@ -151,6 +154,44 @@ namespace ClickPaste
             inputs[1].ki.dwExtraInfo = IntPtr.Zero;
 
             SendInput(2, inputs, inputSize);
+        }
+
+        /// <summary>
+        /// Sends layout-independent text. Printable characters use Unicode packets;
+        /// controls that represent physical keys are emitted as key presses.
+        /// </summary>
+        public static void SendCharViaUnicode(char c)
+        {
+            switch (c)
+            {
+                case '\r':
+                case '\n':
+                    SendKeyPress(VK_RETURN);
+                    break;
+                case '\t':
+                    SendKeyPress(VK_TAB);
+                    break;
+                case '\b':
+                    SendKeyPress(VK_BACK);
+                    break;
+                default:
+                    SendUnicodeChar(c);
+                    break;
+            }
+        }
+
+        private static void SendKeyPress(byte vk)
+        {
+            INPUT[] inputs = new INPUT[2];
+
+            inputs[0].type = INPUT_KEYBOARD;
+            inputs[0].ki.wVk = vk;
+
+            inputs[1].type = INPUT_KEYBOARD;
+            inputs[1].ki.wVk = vk;
+            inputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
+
+            SendInput(2, inputs, Marshal.SizeOf(typeof(INPUT)));
         }
 
         /// <summary>

--- a/Program.cs
+++ b/Program.cs
@@ -243,7 +243,8 @@ namespace ClickPaste
     {
         Forms_SendKeys = 0,
         AutoIt_Send = 1,
-        SendInput_ScanCode = 3  // Scan codes with ALT code fallback - works everywhere including VM consoles
+        SendInput_ScanCode = 3,  // Scan codes with ALT code fallback - works everywhere including VM consoles
+        SendInput_Unicode = 4   // Layout-independent text for RDP and mixed languages
     }
     public enum HotKeyMode
     {
@@ -463,6 +464,12 @@ namespace ClickPaste
                                     foreach (char c in s)
                                     {
                                         Native.SendCharViaScanCode(c);
+                                    }
+                                    break;
+                                case TypeMethod.SendInput_Unicode:
+                                    foreach (char c in s)
+                                    {
+                                        Native.SendCharViaUnicode(c);
                                     }
                                     break;
                             }

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ First of course, you need to have some text in your clipboard.  Then:
 Right-click the notification icon and select Settings.
 
 * You can change between key typing modes,
+  including a layout-independent Unicode mode for mixed-language text over RDP,
 * Set how much delay there is before and between keystrokes, 
 * Trigger a confirmation when the clipboard contains more than a chosen number of characters,
 * Configure what "hot key" combination will be used (Clear the key textbox with delete or backspace if you wish to have *no* hotkey),

--- a/SettingsForm.Designer.cs
+++ b/SettingsForm.Designer.cs
@@ -30,6 +30,7 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsForm));
             this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.Method_Unicode = new System.Windows.Forms.RadioButton();
             this.Method_ScanCode = new System.Windows.Forms.RadioButton();
             this.Method_AutoIt = new System.Windows.Forms.RadioButton();
             this.Method_Forms = new System.Windows.Forms.RadioButton();
@@ -61,31 +62,43 @@
             // 
             // groupBox1
             // 
+            this.groupBox1.Controls.Add(this.Method_Unicode);
             this.groupBox1.Controls.Add(this.Method_ScanCode);
             this.groupBox1.Controls.Add(this.Method_AutoIt);
             this.groupBox1.Controls.Add(this.Method_Forms);
             this.groupBox1.Location = new System.Drawing.Point(12, 12);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(204, 89);
+            this.groupBox1.Size = new System.Drawing.Size(204, 112);
             this.groupBox1.TabIndex = 1;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Typing Method:";
+            //
+            // Method_Unicode
+            //
+            this.Method_Unicode.AutoSize = true;
+            this.Method_Unicode.Location = new System.Drawing.Point(6, 19);
+            this.Method_Unicode.Name = "Method_Unicode";
+            this.Method_Unicode.Size = new System.Drawing.Size(143, 17);
+            this.Method_Unicode.TabIndex = 1;
+            this.Method_Unicode.Tag = "4";
+            this.Method_Unicode.Text = "Unicode (mixed / RDP)";
+            this.Method_Unicode.UseVisualStyleBackColor = true;
             // 
             // Method_ScanCode
             // 
             this.Method_ScanCode.AutoSize = true;
-            this.Method_ScanCode.Location = new System.Drawing.Point(6, 65);
+            this.Method_ScanCode.Location = new System.Drawing.Point(6, 88);
             this.Method_ScanCode.Name = "Method_ScanCode";
             this.Method_ScanCode.Size = new System.Drawing.Size(74, 17);
             this.Method_ScanCode.TabIndex = 4;
             this.Method_ScanCode.Tag = "3";
-            this.Method_ScanCode.Text = "SendInput";
+            this.Method_ScanCode.Text = "SendInput (scan codes)";
             this.Method_ScanCode.UseVisualStyleBackColor = true;
             // 
             // Method_AutoIt
             // 
             this.Method_AutoIt.AutoSize = true;
-            this.Method_AutoIt.Location = new System.Drawing.Point(6, 42);
+            this.Method_AutoIt.Location = new System.Drawing.Point(6, 65);
             this.Method_AutoIt.Name = "Method_AutoIt";
             this.Method_AutoIt.Size = new System.Drawing.Size(81, 17);
             this.Method_AutoIt.TabIndex = 2;
@@ -97,7 +110,7 @@
             // Method_Forms
             // 
             this.Method_Forms.AutoSize = true;
-            this.Method_Forms.Location = new System.Drawing.Point(6, 19);
+            this.Method_Forms.Location = new System.Drawing.Point(6, 42);
             this.Method_Forms.Name = "Method_Forms";
             this.Method_Forms.Size = new System.Drawing.Size(104, 17);
             this.Method_Forms.TabIndex = 1;
@@ -111,9 +124,9 @@
             this.versionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.versionLabel.Font = new System.Drawing.Font("Segoe UI", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.versionLabel.ForeColor = System.Drawing.SystemColors.GrayText;
-            this.versionLabel.Location = new System.Drawing.Point(12, 298);
+            this.versionLabel.Location = new System.Drawing.Point(12, 321);
             this.versionLabel.Name = "versionLabel";
-            this.versionLabel.Size = new System.Drawing.Size(100, 15);
+            this.versionLabel.Size = new System.Drawing.Size(190, 15);
             this.versionLabel.TabIndex = 5;
             this.versionLabel.Text = "v0.0.0";
             this.versionLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -124,7 +137,7 @@
             this.groupBox2.Controls.Add(this.startDelayMS);
             this.groupBox2.Controls.Add(this.label1);
             this.groupBox2.Controls.Add(this.DelayMS);
-            this.groupBox2.Location = new System.Drawing.Point(12, 107);
+            this.groupBox2.Location = new System.Drawing.Point(12, 130);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(204, 79);
             this.groupBox2.TabIndex = 2;
@@ -270,7 +283,7 @@
             // 
             this.Done.Anchor = System.Windows.Forms.AnchorStyles.Bottom;
             this.Done.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.Done.Location = new System.Drawing.Point(159, 284);
+            this.Done.Location = new System.Drawing.Point(159, 307);
             this.Done.Name = "Done";
             this.Done.Size = new System.Drawing.Size(75, 23);
             this.Done.TabIndex = 5;
@@ -283,7 +296,7 @@
             this.groupBox4.Controls.Add(this.confirmOverActive);
             this.groupBox4.Controls.Add(this.label4);
             this.groupBox4.Controls.Add(this.confirmOver);
-            this.groupBox4.Location = new System.Drawing.Point(12, 192);
+            this.groupBox4.Location = new System.Drawing.Point(12, 215);
             this.groupBox4.Name = "groupBox4";
             this.groupBox4.Size = new System.Drawing.Size(204, 75);
             this.groupBox4.TabIndex = 3;
@@ -322,7 +335,7 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoScroll = true;
-            this.ClientSize = new System.Drawing.Size(392, 319);
+            this.ClientSize = new System.Drawing.Size(392, 342);
             this.Controls.Add(this.groupBox4);
             this.Controls.Add(this.versionLabel);
             this.Controls.Add(this.groupBox3);
@@ -374,6 +387,7 @@
         private System.Windows.Forms.RadioButton hotKeyModeType;
         private System.Windows.Forms.RadioButton hotKeyModeTarget;
         private System.Windows.Forms.RadioButton Method_ScanCode;
+        private System.Windows.Forms.RadioButton Method_Unicode;
         private System.Windows.Forms.Label versionLabel;
     }
 }

--- a/SettingsForm.cs
+++ b/SettingsForm.cs
@@ -32,10 +32,11 @@ namespace ClickPaste
             var version = Assembly.GetExecutingAssembly().GetName().Version;
             versionLabel.Text = $"v{version.Major}.{version.Minor}.{version.Build}";
 
-            _methods = new RadioButton[3];
-            _methods[0] = Method_Forms;
-            _methods[1] = Method_AutoIt;
-            _methods[2] = Method_ScanCode;
+            _methods = new RadioButton[4];
+            _methods[0] = Method_Unicode;
+            _methods[1] = Method_Forms;
+            _methods[2] = Method_AutoIt;
+            _methods[3] = Method_ScanCode;
             _modifiers = new CheckBox[4];
             _modifiers[0] = HotKey_Alt;
             _modifiers[1] = HotKey_Control;


### PR DESCRIPTION
## Summary

- add a fourth typing method, `SendInput_Unicode`;
- send printable UTF-16 code units with `KEYEVENTF_UNICODE`, bypassing local and remote keyboard-layout translation;
- keep Enter, Tab, and Backspace as real key presses;
- retain the existing scan-code mode and keep it as the default for VM/browser consoles.

## Why

The existing `SendInput_ScanCode` mode first maps characters through an installed keyboard layout and then emits physical key events. That is useful for Proxmox/noVNC and VM consoles, but an RDP target using a different layout can reinterpret those keys (the `Z`/`Y` case reported in #40 is one example). The new mode is an explicit alternative for Windows/RDP text targets where the intended character matters more than the physical key.

No automatic Alt+Shift switching is required, and mixed Cyrillic/Latin text can be typed in one operation.

## Verification

- Release build completed successfully against .NET Framework 4.8 with dependencies resolved locally.
- The Unicode path was manually validated with mixed Russian/Latin text through RDP in the portable derivative.
- The existing typing modes and the upstream default (`SendInput_ScanCode`) are unchanged.

A ready-to-run derivative build is also available in the fork for practical testing.